### PR TITLE
Add an Awards & Grants section to the home page

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -287,7 +287,7 @@ The dialog's Close / Play demo / Stop buttons. `{typography.control}`, 36 px min
 A control placed over an image carries its own white fill and border, and the image behind it is **not** dimmed. A translucent plate over a poster frame reads as a disabled image, and it is a surface the elevation table does not have.
 
 ### States (mandatory)
-- **Empty** — a sentence, not a panel: "Nothing published yet — the work in progress is on GitHub." Every list surface must have one, and it must not be a bordered box.
+- **Empty** — a sentence, not a panel: "Nothing published yet — the work in progress is on GitHub." Every list surface must have one, and it must not be a bordered box. The one exception is a section whose heading is a claim in itself: Awards & Grants renders nothing at all when the list is empty, because a heading over "nothing yet" states an absence the page was not asked to state. A section may take this exception only by omitting its heading with it. The same holds one level down: a group with no entries is not an empty group, it is absent — the label goes with it, and a list left with a single group carries no label at all, because a label names a split.
 - **Loading** — a `{colors.canvas-soft-2}` skeleton at the final element's dimensions with an opacity pulse. Never a spinner.
 - **Error** — an inline `{colors.error}` message on `{colors.error-soft}` with a retry control, never a bare stack trace.
 

--- a/portfolio-spa/src/app/page.tsx
+++ b/portfolio-spa/src/app/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
+import { AwardList } from "@/components/AwardList";
 import { PublicationList } from "@/components/PublicationList";
 import { Torus } from "@/components/Torus";
+import { awards } from "@/data/awards";
 import { profile } from "@/data/profile";
 import { projects } from "@/data/projects";
 import { publications } from "@/data/publications";
@@ -14,6 +16,7 @@ const elsewhere = [
 /** Reviewed work and unreviewed work are listed apart, and labelled as such. */
 const peerReviewed = publications.filter((publication) => publication.peerReviewed);
 const notPeerReviewed = publications.filter((publication) => !publication.peerReviewed);
+
 
 export default function HomePage() {
   return (
@@ -65,6 +68,19 @@ export default function HomePage() {
           </p>
         )}
       </section>
+
+      {/* ── Awards & Grants ──────────────────────────────────────────────── */}
+      {/* One timeline, not one list per kind: a funded selection and a prize are not the
+          same claim, but the claim is stated on the entry itself (採択 / 受賞), which
+          keeps the record in one chronological run. */}
+      {awards.length > 0 && (
+        <section id="awards" className="mt-16">
+          <h2 className="heading">Awards &amp; Grants</h2>
+          <div className="mt-6">
+            <AwardList awards={awards} />
+          </div>
+        </section>
+      )}
 
       {/* ── Projects ─────────────────────────────────────────────────────── */}
       <section id="projects" className="mt-16">

--- a/portfolio-spa/src/components/AwardList.tsx
+++ b/portfolio-spa/src/components/AwardList.tsx
@@ -1,0 +1,63 @@
+import type { Award } from "@/data/awards";
+
+/**
+ * What the entry is, in the awarding body's own word. It sits on each entry rather than
+ * over a group of them: the list is one timeline, and splitting it by kind would be the
+ * same distinction bought at the cost of the chronology. It is set in the metadata voice
+ * and carries no box — a bordered token would be the badge the system does not have.
+ */
+const kindLabel: Record<Award["kind"], string> = {
+  grant: "採択",
+  award: "受賞",
+  fellowship: "採用",
+};
+
+/** The award list — one run, reverse chronological, no grouping. */
+export function AwardList({ awards }: { awards: Award[] }) {
+  if (awards.length === 0) return null;
+
+  return (
+    <ol className="space-y-6">
+      {awards.map((award) => {
+        // lang is set per entry, not per site, exactly as in the publication list: it is
+        // what puts a Japanese title in the sans face and keeps English out of it.
+        const ja = award.ja ? { lang: "ja" } : {};
+
+        return (
+          <li key={award.title}>
+            {/* The label runs on from the title as text, rather than being pushed to the
+                right edge of the column: flushing it right would be a second column the
+                layout does not have, it would not collapse below 700px, and holding a
+                fixed slot for it takes 42px off the title's measure — enough to break a
+                Japanese title mid-word. As text it costs nothing until it is needed. */}
+            <p className="entry-title" {...ja}>
+              {award.title}{" "}
+              <span className="meta ml-1" lang="ja">
+                {kindLabel[award.kind]}
+              </span>
+            </p>
+
+            {/* The track gets a line of its own rather than a slot in the run below:
+                it is the one long value here, and `dotted` would hold it unbreakable
+                and push the page sideways at 375px instead of letting it fold. */}
+            {award.track && (
+              <p className="meta mt-1" {...ja}>
+                {award.track}
+              </p>
+            )}
+
+            {/* Every value on this line is short Latin, so `dotted` can hold each one
+                together with its separator — a wrap never strands a dot at a line end. */}
+            <p className={`meta dotted ${award.track ? "" : "mt-1"}`}>
+              {award.organization && <span>{award.organization}</span>}
+              {award.amount && <span>{award.amount}</span>}
+              {/* Not a <time>: a Japanese fiscal year is not a date, and "2026" as a
+                  machine value would claim the calendar year instead. */}
+              <span>FY{award.date}</span>
+            </p>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/portfolio-spa/src/data/awards.ts
+++ b/portfolio-spa/src/data/awards.ts
@@ -1,0 +1,57 @@
+export type Award = {
+  /**
+   * The official name of the programme or prize, in the language the awarding body uses
+   * it in — a Japanese programme is named in Japanese, the way the publication list keeps
+   * Japanese papers under their Japanese titles.
+   */
+  title: string;
+  /**
+   * Set when the title is Japanese, so it renders in the sans face rather than mono.
+   * It covers `track` too, which is written in the same language as the title.
+   */
+  ja?: boolean;
+  /**
+   * The domain or course selected within the programme, where it names one. It is a
+   * qualifier on the title, not part of it: carried in the programme's own name it takes
+   * the title to two lines and strands the closing bracket alone on the second.
+   */
+  track?: string;
+  /** Set only when the awarding body is not already named by the title. */
+  organization?: string;
+  /**
+   * Required, and deliberately not optional with a default: a funded selection and a
+   * prize are not the same claim, and a new entry has to state which it is. It is also
+   * what the list splits on if `Awards` and `Grants` ever become two groups.
+   */
+  kind: "grant" | "award" | "fellowship";
+  /** Written as awarded, in the awarding currency. Omitted for awards with no funding. */
+  amount?: string;
+  /**
+   * Japanese programmes are counted in 年度 (fiscal year, April–March), so "2026" here
+   * means FY2026 rather than the calendar year the decision landed in.
+   */
+  date: string;
+};
+
+/**
+ * Reverse chronological, like the publication list. An entry names the programme, the
+ * body, the amount and the year, and stops there: no project description, and no link.
+ */
+export const awards: Award[] = [
+  {
+    title: "未踏ターゲット事業",
+    ja: true,
+    track: "リザバーコンピューティング技術を活用したソフトウェア開発分野",
+    organization: "IPA",
+    kind: "grant",
+    amount: "3,960,000 JPY",
+    date: "2026",
+  },
+  {
+    title: "福岡未踏的人材発掘・育成コンソーシアム(Solve)",
+    ja: true,
+    kind: "grant",
+    amount: "500,000 JPY",
+    date: "2025",
+  },
+];


### PR DESCRIPTION
Adds `Awards & Grants` between Publications and Projects, for the two funded selections — and for the paper prizes and external project selections that will be listed alongside them.

## What it does

- One reverse-chronological run, not a list per kind. Each entry states its own kind (`採択` / `受賞` / `採用`), which is the same distinction a group split would make, without breaking the chronology.
- Entries carry the official Japanese name of the programme, matching how the publication list keeps Japanese papers under their Japanese titles.
- The selected domain (`track`) is a line of its own rather than a parenthetical in the title: carried in the title it wrapped and left `野)` alone on a second line at 1280px.
- `DESIGN.md` gains the empty-state exception this section takes — a heading over "nothing yet" states an absence the page was not asked to state, so the section renders nothing at all when the list is empty, heading included.

## Adding to it later

Set `kind: "award"` and the entry reads `受賞`. `amount` is omitted for a prize with no funding; `organization` is set only when the awarding body is not already named by the title.

## Checks

`npm run lint`, `npm run typecheck` and `npm run build` pass. Verified in the browser at 1280px and 375px: no horizontal overflow, every meta run on one line, section spacing unchanged at 64px.

Reviewed by the design-reviewer agent against DESIGN.md — SHIP, with two pre-existing items left open and reported separately (`PublicationList` still uses bare `·` separators rather than `.dotted`; the section carries no external links, by request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)