### PR TITLE
Label the publication groups in Japanese, glossed in English

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -271,7 +271,7 @@ A link that opens a dialog rather than a page is a `<button>` carrying the same 
 
 Three rules the implementation has to honour:
 - **The separator is not part of the link.** The `·` is generated on a wrapper around the anchor, never on the anchor: inside it, it gets the link's underline and lands in the link's accessible name ("·GitHub"). The wrapper is `white-space: nowrap`, so a wrap never strands a dot at the end of a line, and a run that would wrap is split into two blocks instead (the footer does this below 700 px).
-- **Japanese metadata is set in the sans face** at 13 px, because JetBrains Mono has no CJK and would otherwise fall back mid-line. Venues, author lines, and the dialog's Japanese subtitle take this path.
+- **Japanese metadata is set in the sans face** at 13 px, because JetBrains Mono has no CJK and would otherwise fall back mid-line. Venues, author lines, group labels, an award's programme name and selected domain, and the dialog's Japanese subtitle take this path.
 
 ### Entry
 The one repeating structure, used by publications, projects, and roles: title in `{typography.entry-title}`, one line of prose in `{typography.body}`, one meta line. Entries are separated by `{spacing.lg}` of space; only the `/products` list adds hairlines, because it is long enough to need scanning.

--- a/portfolio-spa/src/app/page.tsx
+++ b/portfolio-spa/src/app/page.tsx
@@ -55,8 +55,20 @@ export default function HomePage() {
 
         {publications.length > 0 ? (
           <div className="mt-6 space-y-10">
-            <PublicationList label="Peer-reviewed" publications={peerReviewed} />
-            <PublicationList label="Not peer-reviewed" publications={notPeerReviewed} />
+            {/* The labels name the venue as well as the review status. That is true of
+                every entry today, but it is a claim `peerReviewed` alone does not carry:
+                a peer-reviewed domestic paper, or an unreviewed international one, needs
+                the label changed rather than the entry filed under it. */}
+            <PublicationList
+              label="査読付き国際会議"
+              labelEn="Peer-reviewed"
+              publications={peerReviewed}
+            />
+            <PublicationList
+              label="国内学会発表(査読無し)"
+              labelEn="Not peer-reviewed"
+              publications={notPeerReviewed}
+            />
           </div>
         ) : (
           <p className="mt-6">

--- a/portfolio-spa/src/components/PublicationList.tsx
+++ b/portfolio-spa/src/components/PublicationList.tsx
@@ -6,16 +6,30 @@ import type { Publication } from "@/data/publications";
  */
 export function PublicationList({
   label,
+  labelEn,
   publications,
 }: {
+  /** Japanese, and carrying `lang` itself: JetBrains Mono has no CJK and would fall back
+   *  mid-string without it, which is why it is the sans face at 13px. */
   label: string;
+  /** The same label in English, so a reader who has no Japanese still gets the split. */
+  labelEn: string;
   publications: Publication[];
 }) {
   if (publications.length === 0) return null;
 
   return (
     <div>
-      <h3 className="meta">{label}</h3>
+      {/* Two languages on one line, the way a Japanese venue already sits in an English
+          meta line: the dot is on the wrapper, so a wrap moves it with the run it belongs
+          to rather than leaving it at the end of a line. */}
+      <h3 className="meta dotted">
+        {/* The space between the two runs is load-bearing twice over: JSX drops the
+            newline, and without it the two `nowrap` spans form one unbreakable line that
+            overruns the right gutter below 375px — and the generated dot lands in the
+            heading's accessible name as a single token, "査読付き国際会議·Peer-reviewed". */}
+        <span lang="ja">{label}</span> <span>{labelEn}</span>
+      </h3>
       <ol className="mt-3 space-y-6">
         {publications.map((publication) => {
           // lang is set per entry, not per site: it is what puts Japanese metadata in the


### PR DESCRIPTION
The two publication groups are now named in Japanese, with the English they replaced kept alongside.

```
査読付き国際会議 · Peer-reviewed
国内学会発表(査読無し) · Not peer-reviewed
```

## Notes

- The Japanese labels name the venue as well as the review status. That is true of every entry today, but it is a claim `peerReviewed` alone does not carry — a peer-reviewed domestic paper needs the label changed rather than the entry filed under it. There is a comment at the call site saying so.
- `lang` moved from the `<h3>` onto the Japanese span. JetBrains Mono has no CJK and would fall back mid-string, and the English run has to stay in the mono face metadata is set in.
- The space between the two runs is load-bearing: both spans are `nowrap` and JSX drops the newline between elements, so without it the heading is one unbreakable line that overruns the right gutter below 375px, and the generated `·` lands in the heading's accessible name as one token.
- `DESIGN.md` enumerated the strings that take the Japanese-in-sans path; group labels and the award fields were missing from the list.

## Checks

`npm run lint` and `npm run typecheck` pass. Verified in the browser at 1280px, 375px and 320px: no overflow past the column, labels on one line at 375 and the English run folding to a second line at 320.

Reviewed by the design-reviewer agent against DESIGN.md — SHIP. One open item is unchanged and not part of this PR: entry meta lines still use bare `·` separators where the group label uses `.dotted`, so the two sit adjacent at different dot values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)